### PR TITLE
feat: close overlay on user interaction when overlay is active

### DIFF
--- a/packages/overlay/src/context/OverlayRenderer.tsx
+++ b/packages/overlay/src/context/OverlayRenderer.tsx
@@ -1,7 +1,7 @@
 import * as ReactDOM from 'react-dom';
-import { useOverlay } from './useOverlay';
 
-const OVERLAY_ID = 'overlay-container';
+import { useOverlay } from './useOverlay';
+import { OVERLAY_ID } from './constants';
 
 export const OverlayRenderer = () => {
   const overlays = useOverlay();

--- a/packages/overlay/src/context/OverlayRenderer.tsx
+++ b/packages/overlay/src/context/OverlayRenderer.tsx
@@ -6,15 +6,14 @@ import { OVERLAY_ID } from './constants';
 export const OverlayRenderer = () => {
   const overlays = useOverlay();
 
-  if (overlays.length === 0) {
-    return null;
-  }
+  if (overlays.length === 0) return null;
 
   return ReactDOM.createPortal(
     <>
       {overlays.map((overlay) => {
         const OverlayComponent = overlay.overlay;
         const props = overlay.props;
+        
         return (
           <OverlayComponent
             key={overlay.overlayKey}

--- a/packages/overlay/src/context/constants.ts
+++ b/packages/overlay/src/context/constants.ts
@@ -1,0 +1,1 @@
+export const OVERLAY_ID = 'uniq-overlay-container';

--- a/packages/overlay/src/context/index.ts
+++ b/packages/overlay/src/context/index.ts
@@ -1,3 +1,2 @@
 export { OverlayContext } from './overlayContext';
-
 export type { OverlayProps } from './types';

--- a/packages/overlay/src/context/overlayContext.tsx
+++ b/packages/overlay/src/context/overlayContext.tsx
@@ -1,10 +1,12 @@
 import { ReactNode } from 'react';
 
 import { useCreateOverlayContainer } from './useCreateOverlayContainer';
+import { useDismissOnUserInteraction } from './useDismissOnUserInteraction';
 import { OverlayRenderer } from './OverlayRenderer';
 
 export const OverlayContext = ({ children }: { children: ReactNode }) => {
   useCreateOverlayContainer();
+  useDismissOnUserInteraction();
 
   return (
     <>

--- a/packages/overlay/src/context/types.ts
+++ b/packages/overlay/src/context/types.ts
@@ -5,6 +5,7 @@ export type OverlayProps = {
   overlayKey: string;
   resolve?: (value: unknown) => void;
   duration?: number;
+  dismissOnInteraction?: boolean;
 };
 
 export type OverlayType<P = OverlayProps> = (props: P) => any;

--- a/packages/overlay/src/context/useCreateOverlayContainer.ts
+++ b/packages/overlay/src/context/useCreateOverlayContainer.ts
@@ -3,15 +3,13 @@ import { OVERLAY_ID } from './constants';
 
 export const useCreateOverlayContainer = () => {
   useEffect(() => {
-    if (document.getElementById(OVERLAY_ID)) {
-      return;
-    }
+    if (document.getElementById(OVERLAY_ID))  return;
 
     const modalEl = document.createElement('div');
 
     modalEl.id = OVERLAY_ID;
     modalEl.style.zIndex = '9999';
-    
+
     document.body.append(modalEl);
 
     return () => {

--- a/packages/overlay/src/context/useCreateOverlayContainer.ts
+++ b/packages/overlay/src/context/useCreateOverlayContainer.ts
@@ -3,7 +3,7 @@ import { OVERLAY_ID } from './constants';
 
 export const useCreateOverlayContainer = () => {
   useEffect(() => {
-    if (document.getElementById(OVERLAY_ID))  return;
+    if (document.getElementById(OVERLAY_ID)) return;
 
     const modalEl = document.createElement('div');
 

--- a/packages/overlay/src/context/useCreateOverlayContainer.ts
+++ b/packages/overlay/src/context/useCreateOverlayContainer.ts
@@ -1,15 +1,17 @@
 import { useEffect } from 'react';
-
-const OVERLAY_ID = 'overlay-container';
+import { OVERLAY_ID } from './constants';
 
 export const useCreateOverlayContainer = () => {
   useEffect(() => {
     if (document.getElementById(OVERLAY_ID)) {
       return;
     }
+
     const modalEl = document.createElement('div');
+
     modalEl.id = OVERLAY_ID;
     modalEl.style.zIndex = '9999';
+    
     document.body.append(modalEl);
 
     return () => {

--- a/packages/overlay/src/context/useDismissOnUserInteraction.ts
+++ b/packages/overlay/src/context/useDismissOnUserInteraction.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+import { overlayStore } from './store';
+
+const DEFAULT_EVENTS = ['mousedown', 'touchstart', 'keydown', 'wheel'];
+
+export const useDismissOnUserInteraction = () => {
+  useEffect(() => {
+    const onInteract = (e: Event) => {
+      const current = overlayStore.getCurrentOverlay();
+
+      if (!current) return;
+
+      const { props } = current;
+
+      if (props.dismissOnInteraction === false) return;
+
+      overlayStore.remove(current.overlayKey);
+    };
+
+    DEFAULT_EVENTS.forEach((ev) => document.addEventListener(ev, onInteract, { capture: true }));
+
+    return () => {
+      DEFAULT_EVENTS.forEach((ev) =>
+        document.removeEventListener(ev, onInteract, { capture: true } as any),
+      );
+    };
+  }, []);
+};

--- a/packages/overlay/src/context/useDismissOnUserInteraction.ts
+++ b/packages/overlay/src/context/useDismissOnUserInteraction.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { overlayStore } from './store';
 
-const DEFAULT_EVENTS = ['mousedown', 'touchstart', 'keydown', 'wheel'];
+const DEFAULT_EVENTS = ['mousedown', 'touchstart', 'keydown'];
 
 export const useDismissOnUserInteraction = () => {
   useEffect(() => {
@@ -14,6 +14,12 @@ export const useDismissOnUserInteraction = () => {
       const { props } = current;
 
       if (props.dismissOnInteraction === false) return;
+
+      if (e.type === 'keydown') {
+        const ke = e as KeyboardEvent;
+
+        if (!(ke.key === 'Escape' || ke.code === 'Escape'))  return;
+      }
 
       overlayStore.remove(current.overlayKey);
     };

--- a/packages/overlay/src/context/useDismissOnUserInteraction.ts
+++ b/packages/overlay/src/context/useDismissOnUserInteraction.ts
@@ -22,7 +22,7 @@ export const useDismissOnUserInteraction = () => {
 
     return () => {
       DEFAULT_EVENTS.forEach((ev) =>
-        document.removeEventListener(ev, onInteract, { capture: true } as any),
+        document.removeEventListener(ev, onInteract, { capture: true }),
       );
     };
   }, []);

--- a/packages/overlay/src/overlay.test.tsx
+++ b/packages/overlay/src/overlay.test.tsx
@@ -230,7 +230,6 @@ describe('Overlay System', () => {
 
       fireEvent.mouseDown(document.body);
       fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
-      fireEvent.wheel(document);
 
       await act(async () => { await Promise.resolve(); });
 

--- a/packages/overlay/src/overlay.test.tsx
+++ b/packages/overlay/src/overlay.test.tsx
@@ -62,14 +62,14 @@ const OverlayTestComponent = () => {
 describe('Overlay System', () => {
   beforeEach(() => {
     const overlayContainer = document.createElement('div');
-    overlayContainer.id = 'overlay-container';
+    overlayContainer.id = 'uniq-overlay-container';
     document.body.appendChild(overlayContainer);
   });
 
   afterEach(() => {
     cleanup();
     overlayStore.clear();
-    const container = document.getElementById('overlay-container');
+    const container = document.getElementById('uniq-overlay-container');
     if (container) {
       document.body.removeChild(container);
     }
@@ -89,7 +89,7 @@ describe('Overlay System', () => {
       const overlayElement = await screen.findByText('Test Message');
       expect(overlayElement).toBeInTheDocument();
 
-      const container = document.getElementById('overlay-container');
+      const container = document.getElementById('uniq-overlay-container');
       expect(container).toContainElement(overlayElement);
 
       await act(async () => {
@@ -197,6 +197,119 @@ describe('Overlay System', () => {
       });
 
       expect(screen.queryByText('Test Message')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('dismissOnInteraction', () => {
+    beforeEach(() => {
+      const overlayContainer = document.createElement('div');
+      overlayContainer.id = 'overlay-container';
+      
+      document.body.appendChild(overlayContainer);
+    });
+
+    afterEach(() => {
+      cleanup();
+      overlayStore.clear();
+      const el = document.getElementById('overlay-container');
+      if (el) document.body.removeChild(el);
+    });
+
+    it('default (false): should NOT close on user interaction', async () => {
+      render(
+        <OverlayContext>
+          <div />
+        </OverlayContext>
+      );
+
+      act(() => {
+        overlay.open(<TestOverlay overlayKey="keep" message="Should stay" />);
+      });
+
+      expect(await screen.findByText('Should stay')).toBeInTheDocument();
+
+      fireEvent.mouseDown(document.body);
+      fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+      fireEvent.wheel(document);
+
+      await act(async () => { await Promise.resolve(); });
+
+      expect(screen.getByText('Should stay')).toBeInTheDocument();
+    });
+
+    it('dismissOnInteraction=true: should close on click', async () => {
+      render(
+        <OverlayContext>
+          <div />
+        </OverlayContext>
+      );
+
+      let resolved: unknown = undefined;
+      act(() => {
+        overlay
+          .open(<TestOverlay overlayKey="click-close" message="Close me" />, {
+            dismissOnInteraction: true,
+          })
+          .then((v) => {
+            resolved = v;
+          });
+      });
+
+      expect(await screen.findByText('Close me')).toBeInTheDocument();
+
+      fireEvent.mouseDown(document.body);
+
+      await act(async () => { await Promise.resolve(); });
+
+      expect(screen.queryByText('Close me')).not.toBeInTheDocument();
+      expect(resolved).toBe('Overlay removed');
+    });
+
+    it('dismissOnInteraction=true: should close on keyboard input', async () => {
+      render(
+        <OverlayContext>
+          <div />
+        </OverlayContext>
+      );
+
+      act(() => {
+        overlay.open(<TestOverlay overlayKey="key-close" message="Close key" />, {
+          dismissOnInteraction: true,
+        });
+      });
+
+      expect(await screen.findByText('Close key')).toBeInTheDocument();
+
+      fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+
+      await act(async () => { await Promise.resolve(); });
+
+      expect(screen.queryByText('Close key')).not.toBeInTheDocument();
+    });
+
+    it('dismissOnInteraction=true: should close only the top-most overlay when multiple are open', async () => {
+      render(
+        <OverlayContext>
+          <div />
+        </OverlayContext>
+      );
+
+      act(() => {
+        overlay.open(<TestOverlay overlayKey="first" message="First" />);
+        overlay.open(<TestOverlay overlayKey="second" message="Second" />, {
+          dismissOnInteraction: true,
+        });
+      });
+
+      expect(await screen.findByText('First')).toBeInTheDocument();
+      expect(await screen.findByText('Second')).toBeInTheDocument();
+
+      fireEvent.mouseDown(document.body);
+
+      await act(async () => { await Promise.resolve(); });
+
+      expect(screen.getByText('First')).toBeInTheDocument();
+      expect(screen.queryByText('Second')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/overlay/src/overlay.ts
+++ b/packages/overlay/src/overlay.ts
@@ -4,7 +4,7 @@ import { overlayStore } from './context/store';
 import { randomId } from './utils';
 import { OverlayProps, ReactOverlayElement } from './context/types';
 
-function open<T>(element: ReactOverlayElement, options?: { duration?: number }): Promise<T> {
+function open<T>(element: ReactOverlayElement, options?: { duration?: number; dismissOnInteraction?: boolean; }): Promise<T> {
   if (!isValidElement(element)) {
     throw new Error('Invalid React element provided to overlay.open');
   }
@@ -18,6 +18,7 @@ function open<T>(element: ReactOverlayElement, options?: { duration?: number }):
   return overlayStore.push(overlayKey, OverlayComponent, {
     ...props,
     duration: options?.duration,
+    dismissOnInteraction: options?.dismissOnInteraction ?? false,
   }) as Promise<T>;
 }
 


### PR DESCRIPTION
- OVERLAY_ID 별도 상수로 분리
- 사용자 인터렉션 ('mousedown', 'touchstart', 'keydown', 'wheel') 발생 시 overlay 닫는 기능 추가

사용 예시
<img width="359" height="141" alt="image" src="https://github.com/user-attachments/assets/07892eda-50e2-4943-8862-000213f12e6f" />

"머지 해줘"